### PR TITLE
Add warning to Qodana Android

### DIFF
--- a/topics/lib_qd.xml
+++ b/topics/lib_qd.xml
@@ -706,5 +706,8 @@
     <chunk id="qodana-intellij-deprecation">Qodana IntelliJ %tech% will be discontinued soon. Use <a href="%tech-link%">technology-specific Qodana %techs%</a> instead.
     </chunk>
 
+    <chunk id="jvm-android-warning">Qodana will currently report no issues if there are plain java modules in your project. See <a href="https://youtrack.jetbrains.com/issue/QD-1575">QD-1575</a> instead.
+    </chunk>
+        
 
 </topic>

--- a/topics/qodana-jvm-android.md
+++ b/topics/qodana-jvm-android.md
@@ -9,6 +9,8 @@
 
 ## Try it now
 
+<p><include src="lib_qd.xml" include-id="jvm-android-warning"/></p>
+
 ### Analyze a project locally
 
 <p><include src="lib_qd.xml" include-id="jvm-project-setup-note"/></p>


### PR DESCRIPTION
Since "many" Android projects are multi-module nowadays and might not have only android modules, it makes sense to inform about this in the setup guide/FAQs.