### PR TITLE
Remove some irrelevant linters

### DIFF
--- a/topics/linters.md
+++ b/topics/linters.md
@@ -41,8 +41,6 @@ Currently, several linters provide inspections for several programming languages
         <td><img src="js.png" dark-src="js_dark.png" alt="JavaScript and TypeScript" width="296"/></td>
         <td>
             <p><a href="qodana-js.md"/>&nbsp;/&nbsp;<code>jetbrains/qodana-js:%image-version%</code></p>
-            <p><a href="qodana-php.md"/>&nbsp;/&nbsp;<code>jetbrains/qodana-php:%image-version%</code></p>
-            <p><a href="qodana-dotnet.md"/>&nbsp;/&nbsp;<code>jetbrains/qodana-dotnet:%image-version%</code></p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Removes php and .net linters from the JS/TS section.


Looks like this right now:

<img width="1169" alt="image" src="https://github.com/JetBrains/Qodana/assets/5013932/1796429d-2902-4cb1-8b47-5a3b27104a3b">
